### PR TITLE
ci: add GitHub Actions workflow for Maven build and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 22
+        uses: actions/setup-java@v4
+        with:
+          java-version: '22'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build and test with Maven
+        run: mvn --batch-mode clean verify
+
+      # - name: Archive artifacts (optional)
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: build-artifact
+      #     path: target/*.jar


### PR DESCRIPTION
Adds an initial GitHub Actions workflow for Continuous Integration.

- Builds the project using Maven and Java 22
- Runs all tests on every push and pull request to main
- Fails early on errors, logs are visible in GitHub Actions

This sets up basic CI for OptSolvX so future changes are automatically tested.

## Note: 
The workflow requires a valid pom.xml in main to run successfully.
Currently, the main branch does not have the latest build setup. Please merge the latest project setup into main before enabling CI. Currently the newest version of the pom.xml file is in the latest version of the branch #4 