### PR TITLE
Add CommonsMathSolver Adapter for AbstractLPModel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,3 @@ replay_pid*
 # Other temporary files
 *.tmp
 *.swp
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-replay_pid*

--- a/src/main/java/org/optsolvx/model/Constraint.java
+++ b/src/main/java/org/optsolvx/model/Constraint.java
@@ -22,9 +22,6 @@ public class Constraint {
     /** Immutable map of variable names to their coefficients. */
     private final Map<String, Double> coefficients;
 
-    /** Constraint type: LEQ (≤), GEQ (≥) or EQ (=). */
-    private final Relationship relationship;
-
     private final Relation relation;
 
     /** Right-hand side value of the constraint. */
@@ -46,10 +43,6 @@ public class Constraint {
         this.name = name;
         this.coefficients = Collections.unmodifiableMap(coefficients);
         this.relation = relation;
-        this.relationship =
-                relation == Relation.LEQ ? Relationship.LEQ :
-                        relation == Relation.GEQ ? Relationship.GEQ :
-                                Relationship.EQ;
         this.rhs = rhs;
     }
 
@@ -69,15 +62,6 @@ public class Constraint {
      */
     public Map<String, Double> getCoefficients() {
         return coefficients;
-    }
-
-    /**
-     * Returns the type of this constraint (LEQ, GEQ, EQ).
-     *
-     * @return constraint relationship
-     */
-    public Relationship getRelationship() {
-        return relationship;
     }
 
     /**
@@ -114,7 +98,7 @@ public class Constraint {
     public String toString() {
         return String.format(
                 "Constraint{name='%s', rel=%s, rhs=%s, coeffs=%s}",
-                name, relationship, rhs, coefficients
+                name, relation, rhs, coefficients
         );
     }
 }

--- a/src/main/java/org/optsolvx/solver/CommonsMathSolver.java
+++ b/src/main/java/org/optsolvx/solver/CommonsMathSolver.java
@@ -8,7 +8,7 @@ import org.optsolvx.model.*;
 
 import java.util.*;
 
-public class CommonsMathSolver {
+public class CommonsMathSolver implements LPSolverAdapter {
 
     public LPSolution solve(AbstractLPModel model) {
         if (model == null || !model.isBuilt()) {
@@ -82,16 +82,12 @@ public class CommonsMathSolver {
     }
 
     private Relationship toCommonsMathRelationship(Constraint.Relation relationship) {
-        switch (relationship) {
-            case LEQ:
-                return Relationship.LEQ;
-            case GEQ:
-                return Relationship.GEQ;
-            case EQ:
-                return Relationship.EQ;
-            default:
-                throw new IllegalArgumentException("Unknown relationship: " + relationship);
-        }
+        return switch (relationship) {
+            case LEQ -> Relationship.LEQ;
+            case GEQ -> Relationship.GEQ;
+            case EQ -> Relationship.EQ;
+            default -> throw new IllegalArgumentException("Unknown relationship: " + relationship);
+        };
     }
 
 

--- a/src/main/java/org/optsolvx/solver/CommonsMathSolver.java
+++ b/src/main/java/org/optsolvx/solver/CommonsMathSolver.java
@@ -1,0 +1,16 @@
+package org.optsolvx.solver;
+
+import org.apache.commons.math3.optim.linear.*;
+import org.apache.commons.math3.optim.nonlinear.scalar.GoalType;
+import org.apache.commons.math3.optim.PointValuePair;
+import org.apache.commons.math3.optim.MaxIter;
+import org.optsolvx.model.*;
+
+import java.util.*;
+
+public class CommonsMathSolver {
+
+p
+
+
+}

--- a/src/main/java/org/optsolvx/solver/CommonsMathSolver.java
+++ b/src/main/java/org/optsolvx/solver/CommonsMathSolver.java
@@ -10,7 +10,89 @@ import java.util.*;
 
 public class CommonsMathSolver {
 
-p
+    public LPSolution solve(AbstractLPModel model) {
+        if (model == null || !model.isBuilt()) {
+            throw new IllegalArgumentException("Model is null or not built.");
+        }
+
+        List<Variable> variables = model.getVariables();
+        int numVariables = variables.size();
+
+        // Objective coefficients, mapped by variable index
+        double[] objectiveCoefficients = new double[numVariables];
+        Map<String, Double> ojectiveCoefficientsMap = model.getObjectiveCoefficients();
+        for (int variableIndex = 0; variableIndex < numVariables; variableIndex++) {
+            String name = variables.get(variableIndex).getName();
+            objectiveCoefficients[variableIndex] = ojectiveCoefficientsMap.getOrDefault(name, 0.0d);
+        }
+
+        // Bounds
+        double[] lowerBounds = new double[numVariables];
+        double[] upperBounds = new double[numVariables];
+        for (int variableIndex = 0; variableIndex < numVariables; variableIndex++) {
+            lowerBounds[variableIndex] = variables.get(variableIndex).getLowerBound();
+            upperBounds[variableIndex] = variables.get(variableIndex).getUpperBound();
+        }
+
+        // Constraints
+        List<LinearConstraint> allConstraints = new ArrayList<>();
+        for (Constraint constraint : model.getConstraints()) {
+            double[] coefficients = new double[numVariables];
+            for (Map.Entry<String, Double> entry : constraint.getCoefficients().entrySet()) {
+                int variableIndex = model.getVariableIndex(entry.getKey());
+                coefficients[variableIndex] = entry.getValue();
+            }
+            Relationship relationship = toCommonsMathRelationship(constraint.getRelation());
+            allConstraints.add(new LinearConstraint(coefficients, relationship, constraint.getRhs()));
+        }
+
+        // Variable bounds as constraints
+        for (int i = 0; i < numVariables; i++) {
+            double[] coefficients = new double[numVariables];
+            coefficients[i] = 1.0d;
+            allConstraints.add(new LinearConstraint(coefficients, Relationship.GEQ, lowerBounds[i]));
+            if (upperBounds[i] < Double.POSITIVE_INFINITY) {
+                allConstraints.add(new LinearConstraint(coefficients, Relationship.LEQ, upperBounds[i]));
+            }
+        }
+
+        LinearObjectiveFunction objective = new LinearObjectiveFunction(objectiveCoefficients, 0);
+        SimplexSolver solver = new SimplexSolver();
+        GoalType goalType = (model.getDirection() == OptimizationDirection.MAXIMIZE)
+                ? GoalType.MAXIMIZE : GoalType.MINIMIZE;
+
+        try {
+            PointValuePair result = solver.optimize(
+                    new MaxIter(100),
+                    objective,
+                    new LinearConstraintSet(allConstraints),
+                    goalType,
+                    new NonNegativeConstraint(true)
+            );
+            double[] solutionVariables = result.getPoint();
+            Map<String, Double> variableMap = new LinkedHashMap<>();
+            for (int i = 0; i < numVariables; i++) {
+                variableMap.put(variables.get(i).getName(), solutionVariables[i]);
+            }
+            double objectiveValue = result.getValue();
+            return new LPSolution(variableMap, objectiveValue, true);
+        } catch (Exception e) {
+            return new LPSolution(Collections.emptyMap(), Double.NaN, false);
+        }
+    }
+
+    private Relationship toCommonsMathRelationship(Constraint.Relation relationship) {
+        switch (relationship) {
+            case LEQ:
+                return Relationship.LEQ;
+            case GEQ:
+                return Relationship.GEQ;
+            case EQ:
+                return Relationship.EQ;
+            default:
+                throw new IllegalArgumentException("Unknown relationship: " + relationship);
+        }
+    }
 
 
 }

--- a/src/main/java/org/optsolvx/solver/LPSolution.java
+++ b/src/main/java/org/optsolvx/solver/LPSolution.java
@@ -5,16 +5,16 @@ import java.util.Map;
 public class LPSolution {
 
     private final Map<String, Double> variableValues; // Variable name -> value
-    private final double objectValue;
+    private final double objectiveValue;
     private final boolean feasible; // true if solution is feasible
 
     public LPSolution(Map<String, Double> variableValues, double objectValue, boolean feasible) {
         this.variableValues = variableValues;
-        this.objectValue = objectValue;
+        this.objectiveValue = objectValue;
         this.feasible = feasible;
     }
 
     public Map<String, Double> getVariableValues() { return variableValues; }
-    public double getObjectValue() { return objectValue; }
+    public double getObjectiveValue() { return objectiveValue; }
     public boolean isFeasible() { return feasible; }
 }

--- a/src/main/java/org/optsolvx/solver/LPSolution.java
+++ b/src/main/java/org/optsolvx/solver/LPSolution.java
@@ -1,0 +1,20 @@
+package org.optsolvx.solver;
+
+import java.util.Map;
+
+public class LPSolution {
+
+    private final Map<String, Double> variableValues; // Variable name -> value
+    private final double objectValue;
+    private final boolean feasible; // true if solution is feasible
+
+    public LPSolution(Map<String, Double> variableValues, double objectValue, boolean feasible) {
+        this.variableValues = variableValues;
+        this.objectValue = objectValue;
+        this.feasible = feasible;
+    }
+
+    public Map<String, Double> getVariableValues() { return variableValues; }
+    public double getObjectValue() { return objectValue; }
+    public boolean isFeasible() { return feasible; }
+}

--- a/src/main/java/org/optsolvx/solver/LPSolverAdapter.java
+++ b/src/main/java/org/optsolvx/solver/LPSolverAdapter.java
@@ -1,0 +1,7 @@
+package org.optsolvx.solver;
+
+import org.optsolvx.model.AbstractLPModel;
+
+public interface LPSolverAdapter {
+    LPSolution solve(AbstractLPModel model);
+}

--- a/src/main/java/org/optsolvx/solver/SolverDemo.java
+++ b/src/main/java/org/optsolvx/solver/SolverDemo.java
@@ -1,0 +1,33 @@
+import org.optsolvx.model.*;
+import org.optsolvx.solver.CommonsMathSolver;
+import org.optsolvx.solver.LPSolution;
+
+import java.util.Map;
+
+public class SolverDemo {
+    public static void main(String[] args) {
+        // 1. Modell aufbauen
+        AbstractLPModel model = new AbstractLPModel();
+        model.addVariable("x", 0, Double.POSITIVE_INFINITY);
+        model.addVariable("y", 0, Double.POSITIVE_INFINITY);
+
+        // Ziel: max x + y
+        model.setObjective(Map.of("x", 1.0d, "y", 1.0d), OptimizationDirection.MAXIMIZE);
+
+        // Constraints:
+        model.addConstraint("c1", Map.of("x", 1.0d, "y", 2.0d), Constraint.Relation.LEQ, 4.0d);
+        model.addConstraint("c2", Map.of("x", 1.0d), Constraint.Relation.LEQ, 3.0d);
+
+        // Modell finalisieren
+        model.build();
+
+        // 2. Solver benutzen
+        CommonsMathSolver solver = new CommonsMathSolver();
+        LPSolution solution = solver.solve(model);
+
+        // 3. Ergebnis ausgeben
+        System.out.println("Variable values: " + solution.getVariableValues());
+        System.out.println("Objective: " + solution.getObjectiveValue());
+        System.out.println("Feasible: " + solution.isFeasible());
+    }
+}

--- a/src/main/java/org/optsolvx/solver/SolverDemo.java
+++ b/src/main/java/org/optsolvx/solver/SolverDemo.java
@@ -1,7 +1,6 @@
-import org.optsolvx.model.*;
-import org.optsolvx.solver.CommonsMathSolver;
-import org.optsolvx.solver.LPSolution;
+package org.optsolvx.solver;
 
+import org.optsolvx.model.*;
 import java.util.Map;
 
 public class SolverDemo {

--- a/src/test/java/org/optsolvx/tests/lp/BaseLPSolverTest.java
+++ b/src/test/java/org/optsolvx/tests/lp/BaseLPSolverTest.java
@@ -1,0 +1,34 @@
+package org.optsolvx.tests.lp;
+
+import org.optsolvx.model.*;
+import org.optsolvx.solver.LPSolution;
+import org.junit.jupiter.api.Test;
+import org.optsolvx.solver.LPSolverAdapter;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public abstract class BaseLPSolverTest {
+    protected abstract LPSolverAdapter getSolver();
+
+    @Test
+    void testSimpleMaximization() {
+        AbstractLPModel model = new AbstractLPModel();
+        model.addVariable("x", 0, 10);
+        model.addVariable("y", 0, 10);
+        model.setObjective(Map.of("x", 3.0d, "y", 5.0d), OptimizationDirection.MAXIMIZE);
+        model.addConstraint("c1", Map.of("x", 2.0d, "y", 1.0d), Constraint.Relation.LEQ, 6.0d);
+        model.addConstraint("c2", Map.of("x", 1.0d, "y", 1.0d), Constraint.Relation.LEQ, 4.0d);
+        model.build();
+
+        LPSolution sol = getSolver().solve(model);
+
+        assertTrue(sol.isFeasible());
+        assertEquals(0.0d, sol.getVariableValues().get("x"), 1e-6);
+        assertEquals(4.0d, sol.getVariableValues().get("y"), 1e-6);
+        assertEquals(20.0d, sol.getObjectiveValue(), 1e-6);
+    }
+
+    // Space for more tests
+}

--- a/src/test/java/org/optsolvx/tests/lp/BaseLPSolverTest.java
+++ b/src/test/java/org/optsolvx/tests/lp/BaseLPSolverTest.java
@@ -30,5 +30,71 @@ public abstract class BaseLPSolverTest {
         assertEquals(20.0d, sol.getObjectiveValue(), 1e-6);
     }
 
-    // Space for more tests
+    @Test
+    void testAddVariable() {
+        AbstractLPModel model = new AbstractLPModel();
+        int idx = model.addVariable("x", 0.0d, 10.0d);
+        assertEquals(0, idx);
+        assertEquals(1, model.getVariables().size());
+        assertEquals("x", model.getVariables().getFirst().getName());
+    }
+
+    @Test
+    void testAddConstraint() {
+        AbstractLPModel model = new AbstractLPModel();
+        model.addVariable("x", 0.0d, 10.0d);
+        Constraint c = model.addConstraint("c1", Map.of("x", 1.0d), Constraint.Relation.LEQ, 5.0d);
+        assertEquals("c1", c.getName());
+        assertEquals(1, model.getConstraints().size());
+        assertEquals(c, model.getConstraints().getFirst());
+    }
+
+    @Test
+    void testBuildSetsBuiltFlag() {
+        AbstractLPModel model = new AbstractLPModel();
+        model.addVariable("x", 0.0d, 10.0d);
+        assertFalse(model.isBuilt());
+        model.build();
+        assertTrue(model.isBuilt());
+    }
+
+    @Test
+    void testAddDuplicateVariableThrows() {
+        AbstractLPModel model = new AbstractLPModel();
+        model.addVariable("x", 0.0d, 10.0d);
+        Exception ex = assertThrows(IllegalArgumentException.class, () -> model.addVariable("x", 0.0d, 5.0d));
+        assertTrue(ex.getMessage().toLowerCase().contains("variable"));
+    }
+
+    @Test
+    void testAddDuplicateConstraintThrows() {
+        AbstractLPModel model = new AbstractLPModel();
+        model.addVariable("x", 0.0d, 10.0d);
+        model.addConstraint("c1", Map.of("x", 1.0d), Constraint.Relation.LEQ, 5.0d);
+        Exception ex = assertThrows(IllegalArgumentException.class, () -> model.addConstraint("c1", Map.of("x", 2.0d), Constraint.Relation.GEQ, 7.0d));
+        assertTrue(ex.getMessage().toLowerCase().contains("constraint"));
+    }
+
+    @Test
+    void testSetDebugEnablesLogging() {
+        AbstractLPModel model = new AbstractLPModel();
+        model.setDebug(true);
+    }
+
+    @Test
+    void testSetDirection() {
+        AbstractLPModel model = new AbstractLPModel();
+        model.setDirection(OptimizationDirection.MINIMIZE);
+        assertEquals(OptimizationDirection.MINIMIZE, model.getDirection());
+    }
+
+    @Test
+    void testModelChangeAfterBuildResetsFlag() {
+        AbstractLPModel model = new AbstractLPModel();
+        model.addVariable("x", 0.0d, 10.0d);
+        model.build();
+        assertTrue(model.isBuilt());
+        model.addVariable("y", 0.0d, 5.0d); // should reset built-Flag
+        assertFalse(model.isBuilt());
+    }
 }

--- a/src/test/java/org/optsolvx/tests/lp/CommonsMathSolverTest.java
+++ b/src/test/java/org/optsolvx/tests/lp/CommonsMathSolverTest.java
@@ -1,0 +1,11 @@
+package org.optsolvx.tests.lp;
+
+import org.optsolvx.solver.LPSolverAdapter;
+import org.optsolvx.solver.CommonsMathSolver;
+
+public class CommonsMathSolverTest extends BaseLPSolverTest{
+    @Override
+    protected LPSolverAdapter getSolver() {
+        return new CommonsMathSolver();
+    }
+}


### PR DESCRIPTION
# Add CommonsMathSolver Adapter for AbstractLPModel

This PR introduces the first solver integration into the abstract interface.

## Key Changes

### CommonsMathSolver Integration

- **Added `CommonsMathSolver`:**
  - Accepts a finalized (`build()`-ed) `AbstractLPModel` and solves the linear program using Apache Commons Math's `SimplexSolver`
  - Extracts variables, bounds, constraints, and objective function directly from the model (no redundant mapping required)
  - Fully supports both maximization and minimization via the `OptimizationDirection` enum

- **Standardized Result Handling:**
  - Introduces or updates `LPSolution` as a single, extensible container for all solver results: variable assignments, objective value, and feasibility flag
  - Ensures results are accessible via variable names (`Map<String, Double>`)

### Tests

- Added generic unit tests for the solver interface and adapter:
  - Abstract base tests (`BaseLPSolverTest`) ensure consistent behavior for any solver integration
  - Concrete test class (`CommonsMathSolverTest`) runs all standard LP tests against the new `CommonsMathSolver`
- The existing demo (`SolverDemo`) remains for manual/interactive exploration
- Test coverage includes:
  - Adding variables and constraints
  - Model build/finalization logic
  - Duplicate name handling
  - Enum-based maximize/minimize direction
  - Model mutability and debug flag