### PR TITLE
build: add compat8 profile (Java 22 default, publish jdk8-classified …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
             </properties>
             <build>
                 <plugins>
+
                     <!-- Second compile of main sources to a separate output dir with release 8 -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -92,6 +93,33 @@
                                 <configuration>
                                     <release>8</release>
                                     <outputDirectory>${project.build.directory}/classes-jdk8</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Ensure META-INF/services files are also present in the Java 8 output -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>3.3.1</version>
+                        <executions>
+                            <execution>
+                                <id>copy-services-compat8</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}/classes-jdk8</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>src/main/resources</directory>
+                                            <includes>
+                                                <include>META-INF/services/**</include>
+                                            </includes>
+                                        </resource>
+                                    </resources>
                                 </configuration>
                             </execution>
                         </executions>
@@ -116,6 +144,7 @@
                             </execution>
                         </executions>
                     </plugin>
+
                 </plugins>
             </build>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,10 @@
     <groupId>org.optsolvx</groupId>
     <artifactId>optsolvx</artifactId>
     <version>0.1.0-SNAPSHOT</version>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- Default: build with Java 22 -->
         <maven.compiler.release>22</maven.compiler.release>
     </properties>
 
@@ -36,6 +38,17 @@
 
     <build>
         <plugins>
+            <!-- Ensure explicit compiler setup (uses <maven.compiler.release>) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <!-- Build main artifact with Java 22 by default -->
+                    <release>${maven.compiler.release}</release>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
@@ -45,7 +58,7 @@
                 </configuration>
             </plugin>
 
-            <!-- ensures JUnit 5 works consistently -->
+            <!-- JUnit 5 -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -53,5 +66,59 @@
             </plugin>
         </plugins>
     </build>
+
+    <!-- Profile to attach an additional JAR compiled for Java 8 as classifier "jdk8" -->
+    <profiles>
+        <profile>
+            <id>compat8</id>
+            <properties>
+                <!-- Skip tests in this profile to avoid Java 9+ APIs in tests -->
+                <maven.test.skip>true</maven.test.skip>
+            </properties>
+            <build>
+                <plugins>
+                    <!-- Second compile of main sources to a separate output dir with release 8 -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.13.0</version>
+                        <executions>
+                            <execution>
+                                <id>compile-compat8</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <release>8</release>
+                                    <outputDirectory>${project.build.directory}/classes-jdk8</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Package the Java 8 classes as an attached JAR with classifier "jdk8" -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>3.3.0</version>
+                        <executions>
+                            <execution>
+                                <id>jar-compat8</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <classesDirectory>${project.build.directory}/classes-jdk8</classesDirectory>
+                                    <classifier>jdk8</classifier>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/src/main/java/org/optsolvx/solver/CommonsMathSolver.java
+++ b/src/main/java/org/optsolvx/solver/CommonsMathSolver.java
@@ -81,14 +81,14 @@ public class CommonsMathSolver implements LPSolverAdapter {
         }
     }
 
+    // Java 8-compatible switch (no switch expressions)
     private Relationship toCommonsMathRelationship(Constraint.Relation relationship) {
-        return switch (relationship) {
-            case LEQ -> Relationship.LEQ;
-            case GEQ -> Relationship.GEQ;
-            case EQ -> Relationship.EQ;
-            default -> throw new IllegalArgumentException("Unknown relationship: " + relationship);
-        };
+        switch (relationship) {
+            case LEQ: return Relationship.LEQ;
+            case GEQ: return Relationship.GEQ;
+            case EQ:  return Relationship.EQ;
+            default: throw new IllegalArgumentException("Unknown relationship: " + relationship);
+        }
     }
-
 
 }

--- a/src/main/java/org/optsolvx/solver/SolverDemo.java
+++ b/src/main/java/org/optsolvx/solver/SolverDemo.java
@@ -1,30 +1,40 @@
 package org.optsolvx.solver;
 
 import org.optsolvx.model.*;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class SolverDemo {
+
     public static void main(String[] args) {
-        // 1. Build the model
+        // 1) Build the model
         AbstractLPModel model = new AbstractLPModel();
-        model.addVariable("x", 0, Double.POSITIVE_INFINITY);
-        model.addVariable("y", 0, Double.POSITIVE_INFINITY);
+        model.addVariable("x", 0.0d, Double.POSITIVE_INFINITY);
+        model.addVariable("y", 0.0d, Double.POSITIVE_INFINITY);
 
-        // Goal: max x + y
-        model.setObjective(Map.of("x", 1.0d, "y", 1.0d), OptimizationDirection.MAXIMIZE);
+        // Objective: max x + y  (Java 8 friendly: no Map.of)
+        Map<String, Double> obj = new LinkedHashMap<>();
+        obj.put("x", 1.0d);
+        obj.put("y", 1.0d);
+        model.setObjective(obj, OptimizationDirection.MAXIMIZE);
 
-        // Constraints:
-        model.addConstraint("c1", Map.of("x", 1.0d, "y", 2.0d), Constraint.Relation.LEQ, 4.0d);
-        model.addConstraint("c2", Map.of("x", 1.0d), Constraint.Relation.LEQ, 3.0d);
+        // Constraints
+        Map<String, Double> c1 = new LinkedHashMap<>();
+        c1.put("x", 1.0d);
+        c1.put("y", 2.0d);
+        model.addConstraint("c1", c1, Constraint.Relation.LEQ, 4.0d);
 
-        // Finalize model
+        Map<String, Double> c2 = new LinkedHashMap<>();
+        c2.put("x", 1.0d);
+        model.addConstraint("c2", c2, Constraint.Relation.LEQ, 3.0d);
+
+        // 2) Finalize and solve
         model.build();
 
-        // 2. Use the solver
         CommonsMathSolver solver = new CommonsMathSolver();
         LPSolution solution = solver.solve(model);
 
-        // 3. Output result
+        // 3) Output
         System.out.println("Variable values: " + solution.getVariableValues());
         System.out.println("Objective: " + solution.getObjectiveValue());
         System.out.println("Feasible: " + solution.isFeasible());

--- a/src/main/resources/META-INF/services/org.optsolvx.solver.LPSolverAdapter
+++ b/src/main/resources/META-INF/services/org.optsolvx.solver.LPSolverAdapter
@@ -1,0 +1,1 @@
+org.optsolvx.solver.CommonsMathSolver


### PR DESCRIPTION
# build: add `compat8` profile (Java 22 default; publish `jdk8`-classified JAR)

## Summary

Enable dual artifacts: keep Java 22 as the default build and additionally publish a Java 8 bytecode JAR for downstream projects (e.g., SBSCL).

## Key Changes

### Dual Artifacts via Maven

* Added `compat8` profile:

  * Re-compiles main sources with `--release 8` to `target/classes-jdk8`.
  * Attaches `*-jdk8.jar` via `maven-jar-plugin` (classifier: `jdk8`).
  * Skips tests in the profile to avoid Java 9+ APIs in test code.
* Default build remains Java 22 (`<release>22</release>`).

### Java 8 Compatibility Fixes

* **CommonsMathSolver**

  * Replaced switch expression with classic `switch` in `toCommonsMathRelationship(...)`.
* **SolverDemo**

  * Replaced `Map.of(...)` with `LinkedHashMap` + `put(...)`.

### Documentation

* README updated:

  * Installation instructions for `compat8`.
  * Dependency example for SBSCL using `<classifier>jdk8</classifier>`.

## How to Build

### Default (Java 22)

```bash
mvn clean package
```

### Optional Java 8 Bytecode Artifact

```bash
mvn -P compat8 -DskipTests clean package
```

**Artifacts**

* `target/optsolvx-<version>.jar` — Java 22 (default)
* `target/optsolvx-<version>-jdk8.jar` — Java 8 bytecode (compatibility)

## Tests

* Build succeeds for Java 22 and `compat8` profile locally.
* Demo (`SolverDemo`) runs unchanged.

**Optional verification**

```bash
javap -verbose -cp target/*-jdk8.jar org.optsolvx.model.AbstractLPModel | grep "major version"   # expect 52
```

## Notes

* No public API changes.
* No dependency updates beyond build plugins.
* Provides a safe Java 8 compatibility path while keeping OptSolvX on Java 22 by default.
